### PR TITLE
Rework gopls start/stop/restart

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true
+}

--- a/extension.json
+++ b/extension.json
@@ -16,5 +16,24 @@
     "process": true,
     "requests": false,
     "filesystem": "readwrite"
-  }
+  },
+  "config": [
+    {
+      "key": "go-nova.enable-gopls",
+      "title": "Enable Language Server",
+      "description": "Use the gopls language server for enhanced functionality. The gopls command should be installed in your search path, or you can specify the full path below.",
+      "link": "https://github.com/golang/tools/blob/master/gopls/README.md",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "key": "go-nova.gopls-path",
+      "title": "Language Server Command",
+      "link": "https://github.com/golang/tools/blob/master/gopls/README.md",
+      "description": "The command name to start the gopls language server. Use an absolute path here if gopls is not in your search path.",
+      "type": "path",
+      "default": "gopls",
+      "filetype": ["public.unix-executable"]
+    }
+  ]
 }


### PR DESCRIPTION
This adds two extension preferences:

* enable/disable gopls (default disabled)
* path to gopls (use a gopls found in the search path)

The start/stop/restart is all new, based on Language Server Extension template from Panic.

There is a hack around what seems like a LanguageClient bug, in that there is not a straight forward way to establish when, after calling stop(), the LanguageClient is fully cleaned up. The `running` property persists in reporting the client to be running. This becomes problematic in restarts because creating a new client fails if the old client hasn’t finished shutting down. For now, the restart scenario just waits a bit between stopping and starting.